### PR TITLE
feat: support custom heading id

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ console.log(content.value);
 Suppose the `example.mdx` has the following content:
 
 ```md
-# Hello, world
+# Hello, world {#hello-world}
 
 ## Title 1
 
@@ -57,7 +57,9 @@ Then the output of the above code is similar to the following:
 export const toc = [{
   "depth": 1,
   "value": "Hello, world",
-  "attributes": {},
+  "attributes": {
+    "id": "hello-world"
+  },
   "children": [{
     "depth": 2,
     "value": "Title 1",
@@ -82,9 +84,9 @@ function MDXContent(props = {}) {
 export default MDXContent;
 ```
 
-
-HTML heading tags (`h1`-`h6`) are supported.
-Custom tags can also be added through options.
+- HTML heading tags (`h1`-`h6`) are supported.
+- Custom tags can also be added through options.
+- `{#id}` syntax needs [remark-heading-id](https://github.com/imcuttle/remark-heading-id) plugin.
 
 ## Options
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "remark-mdx-toc",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "GPL-3.0",
       "dependencies": {
         "estree-util-is-identifier-name": "^2.0.1",
@@ -20,6 +20,7 @@
         "@types/node": "^18.0.3",
         "mdast": "^3.0.0",
         "mdast-util-mdx": "^2.0.0",
+        "remark-custom-heading-id": "^1.0.0",
         "tsx": "^3.7.1",
         "typescript": "^4.7.4"
       }
@@ -947,6 +948,12 @@
       "deprecated": "`mdast` was renamed to `remark`",
       "dev": true
     },
+    "node_modules/mdast-heading-id": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-heading-id/-/mdast-heading-id-1.0.0.tgz",
+      "integrity": "sha512-KM/X3f7Yqr8P4UJI63URPFIn5tjfLREkh30ni8fC+R942md275R/VCJ2XXG7Lonu2f1mNUm5tBRhHPTScR4L1g==",
+      "dev": true
+    },
     "node_modules/mdast-util-definitions": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/mdast-util-definitions/-/mdast-util-definitions-5.1.0.tgz",
@@ -1439,6 +1446,15 @@
         "micromark-util-types": "^1.0.0"
       }
     },
+    "node_modules/micromark-heading-id": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-heading-id/-/micromark-heading-id-1.0.0.tgz",
+      "integrity": "sha512-EUtGl5IIH65v/XELXFkyzZZ8jnIdTRCSvGKgqcB2qLjCZiVLVvKrsue/s6n+97BME072nG8no4M6nPR9pv4FMg==",
+      "dev": true,
+      "dependencies": {
+        "micromark-util-symbol": "^1.0.1"
+      }
+    },
     "node_modules/micromark-util-character": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-1.1.0.tgz",
@@ -1699,9 +1715,9 @@
       }
     },
     "node_modules/micromark-util-symbol": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-1.0.0.tgz",
-      "integrity": "sha512-NZA01jHRNCt4KlOROn8/bGi6vvpEmlXld7EHcRH+aYWUfL3Wc8JLUNNlqUMKa0hhz6GrpUWsHtzPmKof57v0gQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-1.0.1.tgz",
+      "integrity": "sha512-oKDEMK2u5qqAptasDAwWDXq0tG9AssVwAx3E9bBF3t/shRIGsWIRG+cGafs2p/SnDSOecnt6hZPCE2o6lHfFmQ==",
       "dev": true,
       "funding": [
         {
@@ -1783,6 +1799,17 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/remark-custom-heading-id": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/remark-custom-heading-id/-/remark-custom-heading-id-1.0.0.tgz",
+      "integrity": "sha512-t1GPQ6WihSTkwBnJV8h4SSMvQ4YGN718pBzTOy3+DpgiLUIU5H8diDU86gCd0kl+fMG1P2wsL61kzgTok0gZjA==",
+      "dev": true,
+      "dependencies": {
+        "mdast-heading-id": "*",
+        "micromark-heading-id": "*",
+        "unist-util-visit": "^4.1.0"
       }
     },
     "node_modules/remark-mdx": {
@@ -2727,6 +2754,12 @@
       "integrity": "sha1-YmvOlgPtQ/tvsFMkWm5KF/RFeqg=",
       "dev": true
     },
+    "mdast-heading-id": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-heading-id/-/mdast-heading-id-1.0.0.tgz",
+      "integrity": "sha512-KM/X3f7Yqr8P4UJI63URPFIn5tjfLREkh30ni8fC+R942md275R/VCJ2XXG7Lonu2f1mNUm5tBRhHPTScR4L1g==",
+      "dev": true
+    },
     "mdast-util-definitions": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/mdast-util-definitions/-/mdast-util-definitions-5.1.0.tgz",
@@ -3071,6 +3104,15 @@
         "micromark-util-types": "^1.0.0"
       }
     },
+    "micromark-heading-id": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-heading-id/-/micromark-heading-id-1.0.0.tgz",
+      "integrity": "sha512-EUtGl5IIH65v/XELXFkyzZZ8jnIdTRCSvGKgqcB2qLjCZiVLVvKrsue/s6n+97BME072nG8no4M6nPR9pv4FMg==",
+      "dev": true,
+      "requires": {
+        "micromark-util-symbol": "^1.0.1"
+      }
+    },
     "micromark-util-character": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-1.1.0.tgz",
@@ -3201,9 +3243,9 @@
       }
     },
     "micromark-util-symbol": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-1.0.0.tgz",
-      "integrity": "sha512-NZA01jHRNCt4KlOROn8/bGi6vvpEmlXld7EHcRH+aYWUfL3Wc8JLUNNlqUMKa0hhz6GrpUWsHtzPmKof57v0gQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-1.0.1.tgz",
+      "integrity": "sha512-oKDEMK2u5qqAptasDAwWDXq0tG9AssVwAx3E9bBF3t/shRIGsWIRG+cGafs2p/SnDSOecnt6hZPCE2o6lHfFmQ==",
       "dev": true
     },
     "micromark-util-types": {
@@ -3255,6 +3297,17 @@
       "resolved": "https://registry.npmjs.org/property-information/-/property-information-6.1.1.tgz",
       "integrity": "sha512-hrzC564QIl0r0vy4l6MvRLhafmUowhO/O3KgVSoXIbbA2Sz4j8HGpJc6T2cubRVwMwpdiG/vKGfhT4IixmKN9w==",
       "dev": true
+    },
+    "remark-custom-heading-id": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/remark-custom-heading-id/-/remark-custom-heading-id-1.0.0.tgz",
+      "integrity": "sha512-t1GPQ6WihSTkwBnJV8h4SSMvQ4YGN718pBzTOy3+DpgiLUIU5H8diDU86gCd0kl+fMG1P2wsL61kzgTok0gZjA==",
+      "dev": true,
+      "requires": {
+        "mdast-heading-id": "*",
+        "micromark-heading-id": "*",
+        "unist-util-visit": "^4.1.0"
+      }
     },
     "remark-mdx": {
       "version": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@types/node": "^18.0.3",
     "mdast": "^3.0.0",
     "mdast-util-mdx": "^2.0.0",
+    "remark-custom-heading-id": "^1.0.0",
     "tsx": "^3.7.1",
     "typescript": "^4.7.4"
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,13 +48,13 @@ export const remarkMdxToc: Plugin<[RemarkMdxTocOptions?]> = (options = {}) => (
 		// flat toc (share objects in toc, only for iterating)
 		const flatToc: TocEntry[] = [];
 		const createEntry = (node: Heading | MdxJsxFlowElement, depth: number): TocEntry => {
-			let attributes = {};
+			let attributes = (node.data || {}) as TocEntry['attributes'];
 			if (node.type === "mdxJsxFlowElement") {
 				 attributes = Object.fromEntries(
 					node.attributes
 						.filter(attribute => attribute.type === 'mdxJsxAttribute' && typeof attribute.value === 'string')
 						.map(attribute => [(attribute as MdxJsxAttribute).name, attribute.value])
-					);
+					) as TocEntry['attributes'];
 			}
 			return {
 				depth,

--- a/test/example.mdx
+++ b/test/example.mdx
@@ -15,6 +15,8 @@ Sub Content 1
 
 Content 2
 
-<h1 id="h1" a={1+1} {...props}>Hello World 2</h1>
+# Heading with attr {#attr}
 
-<H2>Heading 2</H2>
+<h1 id="h1">Heading with html</h1>
+
+<H1>Heading with component</H1>

--- a/test/test.ts
+++ b/test/test.ts
@@ -4,6 +4,7 @@ import { compileSync } from "@mdx-js/mdx";
 import fs from "fs";
 import path from 'path';
 import { fileURLToPath } from 'url';
+import { remarkHeadingId } from 'remark-custom-heading-id';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -11,6 +12,7 @@ const __dirname = path.dirname(__filename);
 const content = compileSync(fs.readFileSync(path.join(__dirname, "example.mdx")), {
 	jsx: true,
 	remarkPlugins: [
+		remarkHeadingId,
 		[remarkMdxToc, {
 			name: "toc",
 			customTags: [{


### PR DESCRIPTION
## Usage

The `{#id}` syntax is commonly used by Gatsby and Docusaurus

Use it with [remark-custom-heading-id](https://github.com/imcuttle/remark-heading-id) plugin

**mdx file**

```mdx
# Heading1 {#id1}
```

**output**

```
{
  "depth": 1,
  "value": "Heading1",
  "attributes": {
    "id": "id1"
  },
  "children": []
}
```
